### PR TITLE
Fix "gague" typo that breaks the Gauge panel

### DIFF
--- a/src/lib/flot/jquery.flot.gauge.js
+++ b/src/lib/flot/jquery.flot.gauge.js
@@ -482,7 +482,7 @@
             drawText(
                 cellLayout.cx,
                 cellLayout.y + cellLayout.cellMargin + layout.labelMargin + cellLayout.offsetY,
-                "flotGagueLabel" + i,
+                "flotGaugeLabel" + i,
                 gaugeOptionsi.label.formatter ? gaugeOptionsi.label.formatter(item.label, item.data[0][1]) : text,
                 gaugeOptionsi.label);
         }
@@ -502,7 +502,7 @@
             drawText(
                 cellLayout.cx,
                 cellLayout.cy - (gaugeOptionsi.value.font.size / 2),
-                "flotGagueValue" + i,
+                "flotGaugeValue" + i,
                 gaugeOptionsi.value.formatter ? gaugeOptionsi.value.formatter(item.label, item.data[0][1]) : text,
                 gaugeOptionsi.value);
         }
@@ -550,7 +550,7 @@
                 cellLayout.cy
                     + ((layout.thresholdLabelMargin + (layout.thresholdLabelFontSize / 2) + layout.radius)
                         * Math.sin(toRad(a))),
-                "flotGagueThresholdValue" + i,
+                "flotGaugeThresholdValue" + i,
                 gaugeOptionsi.threshold.label.formatter ? gaugeOptionsi.threshold.label.formatter(value) : value,
                 gaugeOptionsi.threshold.label,
                 a);


### PR DESCRIPTION
This typo causes the gauge panel to have overlapping updates, see grafana/grafana#17939, specifically [this comment](https://github.com/grafana/grafana/issues/17939#issuecomment-698059801)